### PR TITLE
Expose Gmail list query params in OpenAPI

### DIFF
--- a/gmail/main.py
+++ b/gmail/main.py
@@ -6,7 +6,7 @@ import sys
 from contextlib import asynccontextmanager
 from typing import Optional, List
 
-from fastapi import FastAPI, Depends, HTTPException, Query
+from fastapi import FastAPI, Depends, HTTPException, Query, Request
 from fastapi.responses import JSONResponse
 import httpx
 
@@ -44,6 +44,43 @@ def get_gmail_client(token: str = Depends(get_token_from_header)) -> GmailClient
     return GmailClient(access_token=token)
 
 
+def _query_value(request: Request, *names: str) -> Optional[str]:
+    """Return the first present query parameter value from a list of aliases."""
+    for name in names:
+        value = request.query_params.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _query_values(request: Request, *names: str) -> Optional[List[str]]:
+    """Return the first non-empty query parameter list from a list of aliases."""
+    for name in names:
+        values = request.query_params.getlist(name)
+        if values:
+            return values
+    return None
+
+
+def _query_int(request: Request, default: int, minimum: int, maximum: int, *names: str) -> int:
+    """Parse and range-check an integer query parameter from known aliases."""
+    value = _query_value(request, *names)
+    if value is None:
+        return default
+
+    try:
+        parsed = int(value)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=f"Invalid integer for {'/'.join(names)}") from exc
+
+    if parsed < minimum or parsed > maximum:
+        raise HTTPException(
+            status_code=422,
+            detail=f"Query parameter {'/'.join(names)} must be between {minimum} and {maximum}",
+        )
+    return parsed
+
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint."""
@@ -54,14 +91,20 @@ async def health_check():
 
 @app.get("/messages")
 async def list_messages(
-    max_results: int = Query(10, ge=1, le=500),
-    page_token: Optional[str] = None,
+    request: Request,
+    max_results: int = Query(10, ge=1, le=500, alias="maxResults"),
+    page_token: Optional[str] = Query(None, alias="pageToken"),
     q: Optional[str] = Query(None, description="Gmail search query"),
-    label_ids: Optional[List[str]] = Query(None),
+    label_ids: Optional[List[str]] = Query(None, alias="labelIds"),
     client: GmailClient = Depends(get_gmail_client),
 ):
     """List messages in user's mailbox."""
     try:
+        max_results = _query_int(request, max_results, 1, 500, "maxResults", "max_results")
+        page_token = _query_value(request, "pageToken", "page_token") or page_token
+        q = _query_value(request, "q") or q
+        label_ids = _query_values(request, "labelIds", "label_ids") or label_ids
+
         return await client.list_messages(
             max_results=max_results,
             page_token=page_token,

--- a/gmail/tests/test_list_messages_query_params.py
+++ b/gmail/tests/test_list_messages_query_params.py
@@ -1,0 +1,56 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import main as gmail_main
+
+
+class FakeGmailClient:
+    def __init__(self):
+        self.calls = []
+
+    async def list_messages(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"messages": []}
+
+
+class ListMessagesQueryParamTests(unittest.TestCase):
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_openapi_exposes_google_style_query_parameters_for_messages(self):
+        operation = gmail_main.app.openapi()["paths"]["/messages"]["get"]
+        parameter_names = {parameter["name"] for parameter in operation["parameters"]}
+
+        self.assertTrue({"q", "maxResults", "pageToken", "labelIds"}.issubset(parameter_names))
+
+    def test_list_messages_accepts_google_style_query_parameter_names(self):
+        response = self.client.get(
+            "/messages",
+            params={
+                "q": "from:harris rendero",
+                "maxResults": "25",
+                "pageToken": "next-page",
+                "labelIds": ["INBOX", "UNREAD"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.calls[-1],
+            {
+                "max_results": 25,
+                "page_token": "next-page",
+                "q": "from:harris rendero",
+                "label_ids": ["INBOX", "UNREAD"],
+            },
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- expose Gmail-style query params for `/messages` in FastAPI/OpenAPI
- preserve compatibility with existing snake_case aliases in the handler
- add a regression test covering both OpenAPI exposure and request forwarding

## Testing
- cd gmail && ../.venv/bin/python -m unittest tests/test_list_messages_query_params.py