### PR TITLE
fix(gmail): enrich list responses with snippet/from/subject

### DIFF
--- a/gmail/client.py
+++ b/gmail/client.py
@@ -1,12 +1,40 @@
 # ABOUTME: HTTP client for Google Gmail API.
 # ABOUTME: Handles all requests to Gmail REST API with proper auth.
 
+import asyncio
 import httpx
-from typing import Optional, Dict, Any
+from typing import Optional, Dict, Any, List
 
 import sys
 sys.path.insert(0, "..")
 from shared.config import get_settings
+
+
+# Headers we surface to agents in enriched list responses. Lower-cased for
+# case-insensitive matching against Gmail's payload headers.
+_ENRICH_HEADERS = ("From", "To", "Subject", "Date")
+_ENRICH_HEADER_LOOKUP = {h.lower(): h.lower() for h in _ENRICH_HEADERS}
+
+# Cap parallel enrichment requests so a maxResults=500 list does not burst
+# 500 concurrent calls into Gmail's per-user quota.
+_ENRICH_CONCURRENCY = 10
+
+
+def _extract_headers(message: Dict[str, Any]) -> Dict[str, str]:
+    """Pull From/To/Subject/Date out of a Gmail message payload.
+
+    Returns a dict keyed by lower-cased header name. Missing headers are
+    omitted rather than returned as empty strings so callers can distinguish
+    "header not present" from "header present but empty".
+    """
+    payload = message.get("payload") or {}
+    headers = payload.get("headers") or []
+    result: Dict[str, str] = {}
+    for header in headers:
+        name = (header.get("name") or "").lower()
+        if name in _ENRICH_HEADER_LOOKUP:
+            result[name] = header.get("value", "")
+    return result
 
 
 class GmailClient:
@@ -76,8 +104,15 @@ class GmailClient:
         page_token: Optional[str] = None,
         q: Optional[str] = None,
         label_ids: Optional[list] = None,
+        enriched: bool = True,
     ) -> Dict[str, Any]:
-        """List messages in user's mailbox."""
+        """List messages in user's mailbox.
+
+        When ``enriched`` is True (default), each returned message stub is
+        decorated with ``snippet``, ``from``, ``to``, ``subject``, ``date``,
+        ``labelIds``, and ``internalDate`` so agents can distinguish results
+        without making an N+1 follow-up call per message.
+        """
         params = {"maxResults": max_results}
         if page_token:
             params["pageToken"] = page_token
@@ -86,7 +121,67 @@ class GmailClient:
         if label_ids:
             params["labelIds"] = label_ids
 
-        return await self._request("GET", f"/users/{user_id}/messages", params=params)
+        response = await self._request("GET", f"/users/{user_id}/messages", params=params)
+
+        if enriched and response.get("messages"):
+            response["messages"] = await self._enrich_message_stubs(
+                response["messages"], user_id
+            )
+        return response
+
+    async def _fetch_message_metadata(
+        self,
+        message_id: str,
+        user_id: str,
+        semaphore: asyncio.Semaphore,
+    ) -> Dict[str, Any]:
+        """Fetch a single message with format=metadata, bounded by a semaphore."""
+        async with semaphore:
+            return await self._request(
+                "GET",
+                f"/users/{user_id}/messages/{message_id}",
+                params={
+                    "format": "metadata",
+                    "metadataHeaders": list(_ENRICH_HEADERS),
+                },
+            )
+
+    async def _enrich_message_stubs(
+        self,
+        stubs: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Decorate {id, threadId} stubs with metadata fetched in parallel.
+
+        On per-message failure (e.g., message deleted between list and get)
+        the original stub is returned so the list call as a whole still
+        succeeds.
+        """
+        semaphore = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+        tasks = [
+            self._fetch_message_metadata(stub["id"], user_id, semaphore)
+            for stub in stubs
+            if stub.get("id")
+        ]
+        metas = await asyncio.gather(*tasks, return_exceptions=True)
+
+        enriched: List[Dict[str, Any]] = []
+        for stub, meta in zip(stubs, metas):
+            if isinstance(meta, BaseException) or not isinstance(meta, dict):
+                enriched.append(stub)
+                continue
+            headers = _extract_headers(meta)
+            enriched.append({
+                **stub,
+                "snippet": meta.get("snippet", ""),
+                "from": headers.get("from", ""),
+                "to": headers.get("to", ""),
+                "subject": headers.get("subject", ""),
+                "date": headers.get("date", ""),
+                "labelIds": meta.get("labelIds", []),
+                "internalDate": meta.get("internalDate", ""),
+            })
+        return enriched
 
     async def get_message(
         self,
@@ -178,14 +273,78 @@ class GmailClient:
         max_results: int = 10,
         page_token: Optional[str] = None,
         q: Optional[str] = None,
+        enriched: bool = True,
     ) -> Dict[str, Any]:
-        """List threads in user's mailbox."""
+        """List threads in user's mailbox.
+
+        When ``enriched`` is True (default), each thread stub is decorated
+        with ``from``, ``to``, ``subject``, and ``date`` taken from the most
+        recent message in the thread. The thread snippet is preserved.
+        """
         params = {"maxResults": max_results}
         if page_token:
             params["pageToken"] = page_token
         if q:
             params["q"] = q
-        return await self._request("GET", f"/users/{user_id}/threads", params=params)
+        response = await self._request("GET", f"/users/{user_id}/threads", params=params)
+
+        if enriched and response.get("threads"):
+            response["threads"] = await self._enrich_thread_stubs(
+                response["threads"], user_id
+            )
+        return response
+
+    async def _fetch_thread_metadata(
+        self,
+        thread_id: str,
+        user_id: str,
+        semaphore: asyncio.Semaphore,
+    ) -> Dict[str, Any]:
+        """Fetch a thread with format=metadata, bounded by a semaphore."""
+        async with semaphore:
+            return await self._request(
+                "GET",
+                f"/users/{user_id}/threads/{thread_id}",
+                params={
+                    "format": "metadata",
+                    "metadataHeaders": list(_ENRICH_HEADERS),
+                },
+            )
+
+    async def _enrich_thread_stubs(
+        self,
+        stubs: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Decorate thread stubs with headers from the most recent message."""
+        semaphore = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+        tasks = [
+            self._fetch_thread_metadata(stub["id"], user_id, semaphore)
+            for stub in stubs
+            if stub.get("id")
+        ]
+        metas = await asyncio.gather(*tasks, return_exceptions=True)
+
+        enriched: List[Dict[str, Any]] = []
+        for stub, meta in zip(stubs, metas):
+            if isinstance(meta, BaseException) or not isinstance(meta, dict):
+                enriched.append(stub)
+                continue
+            messages = meta.get("messages") or []
+            # Use the most recent message so the headers reflect the latest
+            # state of the thread, which is what an agent ranking by recency
+            # would expect to see.
+            latest = messages[-1] if messages else {}
+            headers = _extract_headers(latest)
+            enriched.append({
+                **stub,
+                "from": headers.get("from", ""),
+                "to": headers.get("to", ""),
+                "subject": headers.get("subject", ""),
+                "date": headers.get("date", ""),
+                "messageCount": len(messages),
+            })
+        return enriched
 
     async def get_thread(
         self,
@@ -212,12 +371,72 @@ class GmailClient:
         user_id: str = "me",
         max_results: int = 10,
         page_token: Optional[str] = None,
+        enriched: bool = True,
     ) -> Dict[str, Any]:
-        """List drafts."""
+        """List drafts.
+
+        When ``enriched`` is True (default), each draft is decorated with
+        ``snippet``, ``to``, ``subject``, and ``date`` from the underlying
+        message so agents can identify drafts without N+1 follow-ups.
+        """
         params = {"maxResults": max_results}
         if page_token:
             params["pageToken"] = page_token
-        return await self._request("GET", f"/users/{user_id}/drafts", params=params)
+        response = await self._request("GET", f"/users/{user_id}/drafts", params=params)
+
+        if enriched and response.get("drafts"):
+            response["drafts"] = await self._enrich_draft_stubs(
+                response["drafts"], user_id
+            )
+        return response
+
+    async def _fetch_draft_metadata(
+        self,
+        draft_id: str,
+        user_id: str,
+        semaphore: asyncio.Semaphore,
+    ) -> Dict[str, Any]:
+        """Fetch a draft with format=metadata, bounded by a semaphore."""
+        async with semaphore:
+            return await self._request(
+                "GET",
+                f"/users/{user_id}/drafts/{draft_id}",
+                params={
+                    "format": "metadata",
+                    "metadataHeaders": list(_ENRICH_HEADERS),
+                },
+            )
+
+    async def _enrich_draft_stubs(
+        self,
+        stubs: List[Dict[str, Any]],
+        user_id: str,
+    ) -> List[Dict[str, Any]]:
+        """Decorate draft stubs with snippet/to/subject/date from the message."""
+        semaphore = asyncio.Semaphore(_ENRICH_CONCURRENCY)
+        tasks = [
+            self._fetch_draft_metadata(stub["id"], user_id, semaphore)
+            for stub in stubs
+            if stub.get("id")
+        ]
+        metas = await asyncio.gather(*tasks, return_exceptions=True)
+
+        enriched: List[Dict[str, Any]] = []
+        for stub, meta in zip(stubs, metas):
+            if isinstance(meta, BaseException) or not isinstance(meta, dict):
+                enriched.append(stub)
+                continue
+            message = meta.get("message") or {}
+            headers = _extract_headers(message)
+            enriched.append({
+                **stub,
+                "snippet": message.get("snippet", ""),
+                "to": headers.get("to", ""),
+                "from": headers.get("from", ""),
+                "subject": headers.get("subject", ""),
+                "date": headers.get("date", ""),
+            })
+        return enriched
 
     async def create_draft(
         self,

--- a/gmail/main.py
+++ b/gmail/main.py
@@ -81,6 +81,14 @@ def _query_int(request: Request, default: int, minimum: int, maximum: int, *name
     return parsed
 
 
+def _query_bool(request: Request, default: bool, *names: str) -> bool:
+    """Parse a boolean query parameter while supporting alias fallbacks."""
+    value = _query_value(request, *names)
+    if value is None:
+        return default
+    return value.lower() in {"1", "true", "yes", "on"}
+
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint."""
@@ -96,20 +104,28 @@ async def list_messages(
     page_token: Optional[str] = Query(None, alias="pageToken"),
     q: Optional[str] = Query(None, description="Gmail search query"),
     label_ids: Optional[List[str]] = Query(None, alias="labelIds"),
+    enriched: bool = Query(True, description="Include snippet/from/subject/date for each message"),
     client: GmailClient = Depends(get_gmail_client),
 ):
-    """List messages in user's mailbox."""
+    """List messages in user's mailbox.
+
+    By default each message stub is enriched with snippet/from/to/subject/date
+    so agents can identify results without per-message follow-up calls. Pass
+    ``enriched=false`` to opt out and get the raw Gmail list shape.
+    """
     try:
         max_results = _query_int(request, max_results, 1, 500, "maxResults", "max_results")
         page_token = _query_value(request, "pageToken", "page_token") or page_token
         q = _query_value(request, "q") or q
         label_ids = _query_values(request, "labelIds", "label_ids") or label_ids
+        enriched = _query_bool(request, enriched, "enriched")
 
         return await client.list_messages(
             max_results=max_results,
             page_token=page_token,
             q=q,
             label_ids=label_ids,
+            enriched=enriched,
         )
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
@@ -252,18 +268,26 @@ async def list_threads(
     max_results: int = Query(10, ge=1, le=500, alias="maxResults"),
     page_token: Optional[str] = Query(None, alias="pageToken"),
     q: Optional[str] = Query(None, description="Gmail search query"),
+    enriched: bool = Query(True, description="Include from/to/subject/date for each thread"),
     client: GmailClient = Depends(get_gmail_client),
 ):
-    """List threads in user's mailbox."""
+    """List threads in user's mailbox.
+
+    By default each thread is enriched with from/to/subject/date taken from
+    the most recent message in the thread. Pass ``enriched=false`` to opt
+    out and get the raw Gmail thread list shape.
+    """
     try:
         max_results = _query_int(request, max_results, 1, 500, "maxResults", "max_results")
         page_token = _query_value(request, "pageToken", "page_token") or page_token
         q = _query_value(request, "q") or q
+        enriched = _query_bool(request, enriched, "enriched")
 
         return await client.list_threads(
             max_results=max_results,
             page_token=page_token,
             q=q,
+            enriched=enriched,
         )
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
@@ -301,14 +325,24 @@ async def list_drafts(
     request: Request,
     max_results: int = Query(10, ge=1, le=500, alias="maxResults"),
     page_token: Optional[str] = Query(None, alias="pageToken"),
+    enriched: bool = Query(True, description="Include snippet/to/subject/date for each draft"),
     client: GmailClient = Depends(get_gmail_client),
 ):
-    """List drafts."""
+    """List drafts.
+
+    By default each draft is enriched with snippet/to/subject/date from the
+    underlying message. Pass ``enriched=false`` to opt out.
+    """
     try:
         max_results = _query_int(request, max_results, 1, 500, "maxResults", "max_results")
         page_token = _query_value(request, "pageToken", "page_token") or page_token
+        enriched = _query_bool(request, enriched, "enriched")
 
-        return await client.list_drafts(max_results=max_results, page_token=page_token)
+        return await client.list_drafts(
+            max_results=max_results,
+            page_token=page_token,
+            enriched=enriched,
+        )
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
 

--- a/gmail/tests/test_list_enrichment.py
+++ b/gmail/tests/test_list_enrichment.py
@@ -1,0 +1,95 @@
+# Critical regression tests for serenorg/google-api-services#6.
+#
+# Gmail's list endpoints return only {id, threadId}, which causes agents
+# to misreport searches as broken because they cannot distinguish results.
+# These tests pin down the enrichment behavior so it does not silently
+# regress to the opaque-ID shape.
+
+import asyncio
+import unittest
+from unittest.mock import patch
+
+import client as gmail_client
+
+
+def _make_message_meta(message_id: str, sender: str, subject: str, snippet: str):
+    return {
+        "id": message_id,
+        "threadId": f"thread-{message_id}",
+        "snippet": snippet,
+        "labelIds": ["INBOX"],
+        "internalDate": "1700000000000",
+        "payload": {
+            "headers": [
+                {"name": "From", "value": sender},
+                {"name": "Subject", "value": subject},
+                {"name": "Date", "value": "Fri, 03 Apr 2026 12:00:00 -0700"},
+            ],
+        },
+    }
+
+
+class ListMessagesEnrichmentTests(unittest.TestCase):
+    def test_list_messages_enriches_stubs_with_snippet_from_subject(self):
+        """Default list_messages must surface snippet/from/subject for each result.
+
+        This is the bug from issue #6 — without these fields agents cannot
+        tell whether a search query returned different results from an
+        unfiltered query, and falsely report Gmail search as broken.
+        """
+        client_instance = gmail_client.GmailClient(access_token="fake-token")
+
+        async def fake_request(method, path, params=None, json=None):
+            if path == "/users/me/messages":
+                return {
+                    "messages": [
+                        {"id": "msg-a", "threadId": "thread-msg-a"},
+                        {"id": "msg-b", "threadId": "thread-msg-b"},
+                    ],
+                }
+            if path == "/users/me/messages/msg-a":
+                return _make_message_meta("msg-a", "alice@example.com", "Lunch?", "Hey, lunch tomorrow?")
+            if path == "/users/me/messages/msg-b":
+                return _make_message_meta("msg-b", "bob@example.com", "Q3 review", "The Q3 numbers are in")
+            raise AssertionError(f"unexpected path {path}")
+
+        with patch.object(client_instance, "_request", side_effect=fake_request):
+            result = asyncio.run(client_instance.list_messages(q="from:someone"))
+
+        messages = result["messages"]
+        self.assertEqual(len(messages), 2)
+
+        a, b = messages
+        self.assertEqual(a["id"], "msg-a")
+        self.assertEqual(a["snippet"], "Hey, lunch tomorrow?")
+        self.assertEqual(a["from"], "alice@example.com")
+        self.assertEqual(a["subject"], "Lunch?")
+        self.assertEqual(a["labelIds"], ["INBOX"])
+
+        self.assertEqual(b["from"], "bob@example.com")
+        self.assertEqual(b["subject"], "Q3 review")
+        self.assertEqual(b["snippet"], "The Q3 numbers are in")
+
+    def test_list_messages_enriched_false_makes_no_followup_calls(self):
+        """Opt-out path must skip per-message metadata fetches entirely.
+
+        This guards against accidentally making enrichment unconditional —
+        a 500-message list with mandatory enrichment would burst 500 calls
+        into the user's Gmail quota.
+        """
+        client_instance = gmail_client.GmailClient(access_token="fake-token")
+        observed_paths = []
+
+        async def fake_request(method, path, params=None, json=None):
+            observed_paths.append(path)
+            return {"messages": [{"id": "msg-a", "threadId": "thread-msg-a"}]}
+
+        with patch.object(client_instance, "_request", side_effect=fake_request):
+            result = asyncio.run(client_instance.list_messages(enriched=False))
+
+        self.assertEqual(observed_paths, ["/users/me/messages"])
+        self.assertEqual(result["messages"], [{"id": "msg-a", "threadId": "thread-msg-a"}])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/gmail/tests/test_list_messages_query_params.py
+++ b/gmail/tests/test_list_messages_query_params.py
@@ -48,6 +48,7 @@ class ListMessagesQueryParamTests(unittest.TestCase):
                 "page_token": "next-page",
                 "q": "from:harris rendero",
                 "label_ids": ["INBOX", "UNREAD"],
+                "enriched": True,
             },
         )
 


### PR DESCRIPTION
## Summary
- Gmail's `/messages`, `/threads`, and `/drafts` list endpoints now return enriched stubs by default that include `snippet`, `from`, `to`, `subject`, `date`, and `labelIds` so agents can distinguish search results from unfiltered lists
- Enrichment is implemented via parallel `format=metadata` follow-up fetches bounded by a `_ENRICH_CONCURRENCY=10` semaphore
- Per-message fetch errors fall back to the raw stub so a single deleted message does not break the whole list call
- Opt-out via `?enriched=false` for callers that want the raw Gmail shape (and avoid the extra round-trip)

Fixes serenorg/google-api-services#6

## Test plan
- [x] `gmail/tests/test_list_enrichment.py` — verifies default enrichment surfaces snippet/from/subject
- [x] `gmail/tests/test_list_enrichment.py` — verifies `enriched=false` makes zero follow-up calls
- [x] Existing query-param tests still pass after adding `enriched` kwarg
- [ ] Live integration test against deployed Cloud Run (post-merge)

## Audit
Checked other services for the same opaque-ID pattern:
- Calendar `/events` — fine, returns full events with `summary`/`description`
- Contacts `/contacts` — fine, uses `personFields` parameter
- Docs/Sheets — no list endpoints

Gmail is the only affected service.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
