### PR TITLE
feat(gmail): add agent-friendly POST /send endpoint

### DIFF
--- a/gmail/main.py
+++ b/gmail/main.py
@@ -15,7 +15,7 @@ from shared.auth import get_token_from_header
 from shared.config import get_settings
 
 from client import GmailClient
-from models import SendMessageRequest
+from models import SendMessageRequest, FriendlySendRequest
 
 # Configure logging
 settings = get_settings()
@@ -153,6 +153,42 @@ async def send_message(
     try:
         return await client.send_message(
             raw=request.raw,
+            thread_id=request.thread_id,
+        )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
+
+@app.post("/send")
+async def send_friendly(
+    request: FriendlySendRequest,
+    client: GmailClient = Depends(get_gmail_client),
+):
+    """Send an email with structured to/subject/body fields.
+
+    This is the recommended endpoint for AI agents. The server constructs
+    the RFC 2822 message and base64url-encodes it automatically.
+    """
+    import base64
+    from email.mime.text import MIMEText
+
+    mime = MIMEText(request.body, "plain", "utf-8")
+    mime["To"] = request.to
+    mime["Subject"] = request.subject
+    if request.cc:
+        mime["Cc"] = request.cc
+    if request.bcc:
+        mime["Bcc"] = request.bcc
+    if request.in_reply_to:
+        mime["In-Reply-To"] = request.in_reply_to
+    if request.references:
+        mime["References"] = request.references
+
+    raw = base64.urlsafe_b64encode(mime.as_bytes()).decode("ascii")
+
+    try:
+        return await client.send_message(
+            raw=raw,
             thread_id=request.thread_id,
         )
     except httpx.HTTPStatusError as e:

--- a/gmail/models.py
+++ b/gmail/models.py
@@ -87,6 +87,18 @@ class SendMessageRequest(BaseModel):
     thread_id: Optional[str] = Field(None, alias="threadId", description="Thread ID to reply to")
 
 
+class FriendlySendRequest(BaseModel):
+    """Agent-friendly request to send an email with structured fields."""
+    to: str = Field(..., description="Recipient email address(es), comma-separated for multiple")
+    subject: str = Field(..., description="Email subject line")
+    body: str = Field(..., description="Email body (plain text)")
+    cc: Optional[str] = Field(None, description="CC recipients, comma-separated")
+    bcc: Optional[str] = Field(None, description="BCC recipients, comma-separated")
+    thread_id: Optional[str] = Field(None, alias="threadId", description="Thread ID to reply to")
+    in_reply_to: Optional[str] = Field(None, alias="inReplyTo", description="Message-ID header of the message being replied to")
+    references: Optional[str] = Field(None, description="References header for threading")
+
+
 class DraftRequest(BaseModel):
     """Request to create a draft."""
     message: SendMessageRequest

--- a/gmail/tests/test_friendly_send.py
+++ b/gmail/tests/test_friendly_send.py
@@ -1,0 +1,64 @@
+import base64
+import unittest
+from email import message_from_bytes
+
+from fastapi.testclient import TestClient
+
+import main as gmail_main
+
+
+class FakeGmailClient:
+    def __init__(self):
+        self.calls = []
+
+    async def send_message(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"id": "msg_abc123", "threadId": "thread_abc123", "labelIds": ["SENT"]}
+
+
+class FriendlySendTests(unittest.TestCase):
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_send_friendly_constructs_valid_rfc2822_message(self):
+        """POST /send should build an RFC 2822 MIME message and base64url-encode it."""
+        response = self.client.post(
+            "/send",
+            json={
+                "to": "alice@example.com",
+                "subject": "Hello from agent",
+                "body": "This is a test email.",
+                "cc": "bob@example.com",
+                "bcc": "charlie@example.com",
+                "inReplyTo": "<original-msg-id@example.com>",
+                "references": "<original-msg-id@example.com>",
+                "threadId": "thread_xyz",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+
+        # Verify the client was called with the right thread_id
+        call = self.fake_client.calls[-1]
+        self.assertEqual(call["thread_id"], "thread_xyz")
+
+        # Decode the raw payload and verify RFC 2822 headers
+        raw_bytes = base64.urlsafe_b64decode(call["raw"])
+        msg = message_from_bytes(raw_bytes)
+
+        self.assertEqual(msg["To"], "alice@example.com")
+        self.assertEqual(msg["Subject"], "Hello from agent")
+        self.assertEqual(msg["Cc"], "bob@example.com")
+        self.assertEqual(msg["Bcc"], "charlie@example.com")
+        self.assertEqual(msg["In-Reply-To"], "<original-msg-id@example.com>")
+        self.assertEqual(msg["References"], "<original-msg-id@example.com>")
+        self.assertIn("This is a test email.", msg.get_payload(decode=True).decode())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- Adds `FriendlySendRequest` model with structured `to`, `subject`, `body`, `cc`, `bcc`, `threadId`, `inReplyTo`, and `references` fields
- Adds `POST /send` endpoint that constructs an RFC 2822 MIME message and base64url-encodes it server-side, so AI agents can send emails without manually encoding
- Adds test verifying the endpoint correctly builds and encodes the MIME message with all headers

Closes #8

## Test plan

- [x] `POST /send` with `{"to": "...", "subject": "...", "body": "..."}` constructs a valid RFC 2822 message
- [x] All headers (To, Subject, Cc, Bcc, In-Reply-To, References) are set correctly
- [x] The `raw` payload sent to `client.send_message` is valid base64url-encoded MIME
- [x] `threadId` is forwarded to the underlying client call
- [x] All existing tests pass (5/5)

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com