### PR TITLE
feat(gmail): add attachment download endpoint

### DIFF
--- a/gmail/client.py
+++ b/gmail/client.py
@@ -193,6 +193,22 @@ class GmailClient:
         params = {"format": format}
         return await self._request("GET", f"/users/{user_id}/messages/{message_id}", params=params)
 
+    async def get_attachment(
+        self,
+        message_id: str,
+        attachment_id: str,
+        user_id: str = "me",
+    ) -> Dict[str, Any]:
+        """Download a specific attachment from a message.
+
+        Returns Gmail's MessagePartBody shape: {"size": int, "data": str}
+        where ``data`` is base64url-encoded attachment bytes.
+        """
+        return await self._request(
+            "GET",
+            f"/users/{user_id}/messages/{message_id}/attachments/{attachment_id}",
+        )
+
     async def send_message(
         self,
         raw: str,

--- a/gmail/main.py
+++ b/gmail/main.py
@@ -144,6 +144,27 @@ async def get_message(
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
 
 
+@app.get("/messages/{message_id}/attachments/{attachment_id}")
+async def get_attachment(
+    message_id: str,
+    attachment_id: str,
+    client: GmailClient = Depends(get_gmail_client),
+):
+    """Download a specific attachment from a message.
+
+    Proxies Gmail's ``users.messages.attachments.get`` endpoint. The response
+    payload matches the Gmail API MessagePartBody shape, with ``data`` holding
+    the base64url-encoded attachment bytes.
+    """
+    try:
+        return await client.get_attachment(
+            message_id=message_id,
+            attachment_id=attachment_id,
+        )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
+
 @app.post("/messages/send")
 async def send_message(
     request: SendMessageRequest,

--- a/gmail/tests/test_get_attachment.py
+++ b/gmail/tests/test_get_attachment.py
@@ -1,0 +1,38 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import main as gmail_main
+
+
+class FakeGmailClient:
+    def __init__(self):
+        self.calls = []
+
+    async def get_attachment(self, **kwargs):
+        self.calls.append(kwargs)
+        return {"size": 12345, "data": "aGVsbG8td29ybGQ"}
+
+
+class GetAttachmentRouteTests(unittest.TestCase):
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_get_attachment_proxies_ids_and_returns_gmail_payload(self):
+        response = self.client.get("/messages/MSG123/attachments/ATT456")
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"size": 12345, "data": "aGVsbG8td29ybGQ"})
+        self.assertEqual(
+            self.fake_client.calls[-1],
+            {"message_id": "MSG123", "attachment_id": "ATT456"},
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `GET /messages/{message_id}/attachments/{attachment_id}` to the Gmail service, proxying Gmail's `users.messages.attachments.get`.
- Response matches Gmail's `MessagePartBody` shape (`size`, `data` base64url-encoded).
- Implements `GmailClient.get_attachment()` in `gmail/client.py`.
- Adds a critical route test that verifies id-proxying and payload passthrough.

Closes #10.

## Test plan
- [x] `python3 -m pytest gmail/tests/` passes (6 tests, all green).
- [ ] Post-deploy: `curl -H "Authorization: Bearer <TOKEN>" https://seren-gmail-.../messages/<MID>/attachments/<AID>` returns base64url data.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com