### PR TITLE
fix(ci): chain gcloud run deploy to every cloudbuild-*.yaml

### DIFF
--- a/cloudbuild-auth.yaml
+++ b/cloudbuild-auth.yaml
@@ -1,12 +1,30 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
+  # auth service is self-contained (no shared/ dependency), so the build
+  # context is ./auth, unlike the other Google API services.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:latest'
       - '-f'
       - 'auth/Dockerfile'
       - './auth'
 
+  # Roll out the exact digest that was just built.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-google-auth'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:latest'

--- a/cloudbuild-calendar.yaml
+++ b/cloudbuild-calendar.yaml
@@ -1,12 +1,28 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:latest'
       - '-f'
       - 'calendar/Dockerfile'
       - '.'
 
+  # Roll out the exact digest that was just built.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-calendar'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:latest'

--- a/cloudbuild-contacts.yaml
+++ b/cloudbuild-contacts.yaml
@@ -1,12 +1,28 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:latest'
       - '-f'
       - 'contacts/Dockerfile'
       - '.'
 
+  # Roll out the exact digest that was just built.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-contacts'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:latest'

--- a/cloudbuild-docs.yaml
+++ b/cloudbuild-docs.yaml
@@ -1,12 +1,28 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:latest'
       - '-f'
       - 'docs/Dockerfile'
       - '.'
 
+  # Roll out the exact digest that was just built.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-docs'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:latest'

--- a/cloudbuild-gmail.yaml
+++ b/cloudbuild-gmail.yaml
@@ -1,12 +1,29 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:latest'
       - '-f'
       - 'gmail/Dockerfile'
       - '.'
 
+  # Roll out the exact digest that was just built. Pinning to $COMMIT_SHA
+  # (not :latest) makes the rollout deterministic and rollback by SHA trivial.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-gmail'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:latest'

--- a/cloudbuild-sheets.yaml
+++ b/cloudbuild-sheets.yaml
@@ -1,12 +1,28 @@
 steps:
+  # Build with both :$COMMIT_SHA (traceable) and :latest (convenience) tags.
   - name: 'gcr.io/cloud-builders/docker'
     args:
       - 'build'
+      - '-t'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:$COMMIT_SHA'
       - '-t'
       - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:latest'
       - '-f'
       - 'sheets/Dockerfile'
       - '.'
 
+  # Roll out the exact digest that was just built.
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'gcloud'
+    args:
+      - 'run'
+      - 'deploy'
+      - 'seren-sheets'
+      - '--image=us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:$COMMIT_SHA'
+      - '--region=us-central1'
+      - '--allow-unauthenticated'
+      - '--quiet'
+
 images:
+  - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:$COMMIT_SHA'
   - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:latest'

--- a/tests/test_cloudbuild_configs.py
+++ b/tests/test_cloudbuild_configs.py
@@ -1,0 +1,88 @@
+# Critical regression test for serenorg/google-api-services#15.
+#
+# Every cloudbuild-*.yaml at the repo root MUST contain both a docker
+# build step and a Cloud Run deploy step. Build-only pipelines silently
+# skip production rollout and caused the false-positive serenorg/seren-core#143
+# (stale Gmail revision reported as a gateway bug).
+
+from __future__ import annotations
+
+import pathlib
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# The auth deploy wiring is separate from the others; keep this list
+# anchored on the filename and do not exclude new configs so a future
+# cloudbuild-*.yaml that someone adds is covered automatically.
+CLOUDBUILD_GLOB = "cloudbuild-*.yaml"
+
+
+class CloudBuildDeployCoverageTests(unittest.TestCase):
+    def test_every_cloudbuild_config_builds_and_deploys(self):
+        configs = sorted(REPO_ROOT.glob(CLOUDBUILD_GLOB))
+        self.assertGreater(
+            len(configs),
+            0,
+            "No cloudbuild-*.yaml files found — test is looking in the wrong directory.",
+        )
+
+        missing_deploy: list[str] = []
+        missing_build: list[str] = []
+
+        for config in configs:
+            text = config.read_text()
+            # Build step: any Cloud Build step invoking `docker` with `build`.
+            has_build = "cloud-builders/docker" in text and "'build'" in text
+            # Deploy step: a `gcloud run deploy` invocation. Accept either the
+            # gcloud builder image or an inline entrypoint.
+            has_deploy = "'run'" in text and "'deploy'" in text
+
+            if not has_build:
+                missing_build.append(config.name)
+            if not has_deploy:
+                missing_deploy.append(config.name)
+
+        self.assertEqual(
+            missing_build,
+            [],
+            f"cloudbuild files missing a docker build step: {missing_build}",
+        )
+        self.assertEqual(
+            missing_deploy,
+            [],
+            "cloudbuild files missing a `gcloud run deploy` step "
+            f"(they only build+push, production will not roll out): {missing_deploy}",
+        )
+
+    def test_deploy_pins_image_to_commit_sha(self):
+        """Deploys must reference $COMMIT_SHA, not :latest.
+
+        Pinning to :latest deploys whatever was last pushed — including
+        concurrent builds — and makes rollback-by-SHA impossible. Every
+        deploy step must use $COMMIT_SHA in its --image flag.
+        """
+        offenders: list[str] = []
+        for config in sorted(REPO_ROOT.glob(CLOUDBUILD_GLOB)):
+            text = config.read_text()
+            if "'deploy'" not in text:
+                continue  # covered by the previous test
+            # Find the --image= line in the deploy step and assert SHA pinning.
+            image_lines = [
+                line.strip()
+                for line in text.splitlines()
+                if "--image=" in line
+            ]
+            if not any("$COMMIT_SHA" in line for line in image_lines):
+                offenders.append(config.name)
+
+        self.assertEqual(
+            offenders,
+            [],
+            "cloudbuild deploy steps must pin --image to $COMMIT_SHA, "
+            f"not :latest (non-deterministic rollout): {offenders}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Every `cloudbuild-*.yaml` now deploys to Cloud Run after pushing the image. Previously only the build+push step ran, so `main` drifted from what was actually serving traffic.

- Every image is now tagged **both** `:$COMMIT_SHA` and `:latest`; the deploy step references the SHA digest so rollouts are atomic with the build and rollbacks are SHA-addressable
- Adds `tests/test_cloudbuild_configs.py` — enforces that every `cloudbuild-*.yaml` contains a build step **and** a deploy step pinned to `$COMMIT_SHA`

Fixes #15.

## Why this matters

This gap caused serenorg/seren-core#143 — a false-positive gateway bug report where a Gmail attachment route merged as `bf80da3` on 2026-04-19 sat undeployed for 10 days. The Cloud Run revision running 2026-04-20 did not have the route, so FastAPI returned `{"detail":"Not Found"}` — shaped exactly like a gateway path-substitution bug.

After a manual redeploy earlier today, the same endpoint downloads 1.7 MB PDFs end-to-end with 611-character `attachmentId` path params. The code was always fine; CI just didn't ship it.

## Files changed

```
cloudbuild-auth.yaml           (seren-google-auth)
cloudbuild-calendar.yaml       (seren-calendar)
cloudbuild-contacts.yaml       (seren-contacts)
cloudbuild-docs.yaml           (seren-docs)
cloudbuild-gmail.yaml          (seren-gmail)
cloudbuild-sheets.yaml         (seren-sheets)
tests/__init__.py              (new)
tests/test_cloudbuild_configs.py (new)
```

## One-time service account grants (do before merging)

The Cloud Build SA running these pipelines must have:
- `roles/run.admin` on the project
- `roles/iam.serviceAccountUser` on the Cloud Run runtime SA

Without these the deploy step will fail with a permissions error.

## Test plan

- [x] `python3 -m unittest tests.test_cloudbuild_configs -v` — both tests pass (build+deploy presence, SHA pinning)
- [x] `python3 -c 'import yaml, glob; [yaml.safe_load(open(f)) for f in glob.glob("cloudbuild-*.yaml")]'` — all YAML parses cleanly
- [ ] Post-merge: confirm a real Cloud Build trigger on this repo runs the deploy step end-to-end for one service (recommend gmail since it was just redeployed and has live traffic)

## Notes

- `cloudbuild-nano-banana.yaml` is not on `main` yet (untracked in the working copy), so it is not included here. When it lands, the new test will require a deploy step in that file too.
- Service names in the deploy steps match the services currently running in `us-central1`. `seren-contacts`, `seren-docs`, and `seren-sheets` do not exist yet; the first CI run will create them.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
