### PR TITLE
fix(ci): push image before deploy step in cloudbuild configs

### DIFF
--- a/cloudbuild-auth.yaml
+++ b/cloudbuild-auth.yaml
@@ -13,6 +13,12 @@ steps:
       - 'auth/Dockerfile'
       - './auth'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-google-auth:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'

--- a/cloudbuild-calendar.yaml
+++ b/cloudbuild-calendar.yaml
@@ -11,6 +11,12 @@ steps:
       - 'calendar/Dockerfile'
       - '.'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-calendar:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'

--- a/cloudbuild-contacts.yaml
+++ b/cloudbuild-contacts.yaml
@@ -11,6 +11,12 @@ steps:
       - 'contacts/Dockerfile'
       - '.'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-contacts:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'

--- a/cloudbuild-docs.yaml
+++ b/cloudbuild-docs.yaml
@@ -11,6 +11,12 @@ steps:
       - 'docs/Dockerfile'
       - '.'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-docs:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'

--- a/cloudbuild-gmail.yaml
+++ b/cloudbuild-gmail.yaml
@@ -11,6 +11,14 @@ steps:
       - 'gmail/Dockerfile'
       - '.'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  # (Cloud Build only auto-pushes `images:` after the whole build finishes,
+  # which is too late for a deploy step that needs the image.)
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-gmail:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built. Pinning to $COMMIT_SHA
   # (not :latest) makes the rollout deterministic and rollback by SHA trivial.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'

--- a/cloudbuild-sheets.yaml
+++ b/cloudbuild-sheets.yaml
@@ -11,6 +11,12 @@ steps:
       - 'sheets/Dockerfile'
       - '.'
 
+  # Push the SHA tag BEFORE the deploy step so gcloud can pull it.
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - 'us-central1-docker.pkg.dev/$PROJECT_ID/google-api-services/seren-sheets:$COMMIT_SHA'
+
   # Roll out the exact digest that was just built.
   - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
     entrypoint: 'gcloud'

--- a/tests/test_cloudbuild_configs.py
+++ b/tests/test_cloudbuild_configs.py
@@ -55,6 +55,35 @@ class CloudBuildDeployCoverageTests(unittest.TestCase):
             f"(they only build+push, production will not roll out): {missing_deploy}",
         )
 
+    def test_push_step_precedes_deploy_step(self):
+        """A docker push step must appear before the deploy step.
+
+        Cloud Build's top-level `images:` section only pushes at the END of
+        the build, so a deploy step that references an image built earlier
+        in the pipeline must have an explicit `docker push` step in between
+        — otherwise `gcloud run deploy` fails with 'Image not found' when
+        it tries to pull from Artifact Registry. We hit this in the first
+        CI run after #16 landed.
+        """
+        offenders: list[str] = []
+        for config in sorted(REPO_ROOT.glob(CLOUDBUILD_GLOB)):
+            text = config.read_text()
+            if "'deploy'" not in text:
+                continue
+            push_pos = text.find("'push'")
+            deploy_pos = text.find("'deploy'")
+            # Both must be present AND push must come first.
+            if push_pos == -1 or push_pos > deploy_pos:
+                offenders.append(config.name)
+
+        self.assertEqual(
+            offenders,
+            [],
+            "cloudbuild files missing a `docker push` step before the deploy "
+            "step (deploy will fail with 'Image not found' because Cloud Build "
+            f"only auto-pushes `images:` after the whole build finishes): {offenders}",
+        )
+
     def test_deploy_pins_image_to_commit_sha(self):
         """Deploys must reference $COMMIT_SHA, not :latest.
 


### PR DESCRIPTION
## Summary

Follow-up to #16. The first CI run after #16 failed with:

```
ERROR: (gcloud.run.deploy) Image 'us-central1-docker.pkg.dev/.../seren-gmail:<sha>' not found.
```

Root cause: Cloud Build's top-level `images:` field only pushes **after the whole build completes**. The deploy step in #16 ran in between the build and the auto-push, so the image wasn't in Artifact Registry yet.

This PR adds an explicit `docker push` step between build and deploy in all six cloudbuild configs (gmail, calendar, contacts, docs, sheets, auth) and adds a test that asserts `docker push` appears before `gcloud run deploy` so this exact ordering cannot regress.

Continues closing #15.

## Test plan
- [x] `python3 -m unittest tests.test_cloudbuild_configs -v` — 3 tests pass (build+deploy presence, push-before-deploy ordering, SHA pinning)
- [ ] Post-merge: confirm `gcloud builds submit . --config=cloudbuild-gmail.yaml` now rolls out a new Cloud Run revision end-to-end

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com