### PR TITLE
fix(auth): add Drive/Docs OAuth scopes (#18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,16 @@ seren mcp call execute_paid_api --publisher gmail --method GET --path /messages
 - `https://www.googleapis.com/auth/calendar`
 - `https://www.googleapis.com/auth/calendar.events`
 
+**Drive / Docs:**
+
+- `https://www.googleapis.com/auth/drive.metadata.readonly` — required for `files.list` discovery/search
+- `https://www.googleapis.com/auth/drive.readonly` — required for `files.export` content download
+- `https://www.googleapis.com/auth/documents.readonly` — required for Docs API read by document ID
+
+> **Re-consent required after scope changes.** Existing refresh tokens do not
+> automatically gain newly added scopes — affected users must run the OAuth
+> flow again so a refresh token with the expanded scope set is stored.
+
 ## Related
 
 - Seren Publishers: `gmail`, `google-calendar`

--- a/auth/config.py
+++ b/auth/config.py
@@ -21,14 +21,20 @@ class Settings(BaseSettings):
     google_token_url: str = "https://oauth2.googleapis.com/token"
     google_userinfo_url: str = "https://www.googleapis.com/oauth2/v2/userinfo"
 
-    # OAuth scopes for Gmail and Calendar
+    # OAuth scopes for Gmail, Calendar, Drive, and Docs.
+    # Drive scopes are required so the Docs/Drive publishers can discover
+    # documents via files.list and export content via files.export
+    # (issue #18 — ACCESS_TOKEN_SCOPE_INSUFFICIENT on DriveFiles.List).
     google_scopes: str = (
         "openid email profile "
         "https://www.googleapis.com/auth/gmail.readonly "
         "https://www.googleapis.com/auth/gmail.send "
         "https://www.googleapis.com/auth/gmail.modify "
         "https://www.googleapis.com/auth/calendar "
-        "https://www.googleapis.com/auth/calendar.events"
+        "https://www.googleapis.com/auth/calendar.events "
+        "https://www.googleapis.com/auth/drive.metadata.readonly "
+        "https://www.googleapis.com/auth/drive.readonly "
+        "https://www.googleapis.com/auth/documents.readonly"
     )
 
     # Database for token storage

--- a/tests/test_google_scopes.py
+++ b/tests/test_google_scopes.py
@@ -1,0 +1,64 @@
+# Critical regression test for serenorg/google-api-services#18.
+#
+# The OAuth scope list minted by the auth service must include every scope
+# required by a deployed publisher in this repo. Drive/Docs publishers were
+# returning ACCESS_TOKEN_SCOPE_INSUFFICIENT on DriveFiles.List because the
+# auth service was minting Gmail/Calendar-only tokens. This test fails if a
+# future scope removal breaks Drive discovery, Drive export, or Docs reads.
+
+from __future__ import annotations
+
+import pathlib
+import sys
+import unittest
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+AUTH_DIR = REPO_ROOT / "auth"
+
+# The auth service's config.py is imported directly so the test runs without
+# needing the rest of the FastAPI stack installed.
+if str(AUTH_DIR) not in sys.path:
+    sys.path.insert(0, str(AUTH_DIR))
+
+
+REQUIRED_SCOPES = {
+    # Gmail publisher
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.send",
+    "https://www.googleapis.com/auth/gmail.modify",
+    # Calendar publisher
+    "https://www.googleapis.com/auth/calendar",
+    "https://www.googleapis.com/auth/calendar.events",
+    # Drive publisher — files.list discovery (issue #18)
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
+    # Drive publisher — files.export content download (issue #18)
+    "https://www.googleapis.com/auth/drive.readonly",
+    # Docs publisher — documents.get by document ID (issue #18)
+    "https://www.googleapis.com/auth/documents.readonly",
+}
+
+
+class GoogleScopesCoverageTests(unittest.TestCase):
+    def test_settings_google_scopes_covers_all_deployed_publishers(self):
+        # Provide the env vars Settings() requires so import succeeds.
+        import os
+
+        os.environ.setdefault("GOOGLE_CLIENT_ID", "test-client")
+        os.environ.setdefault("GOOGLE_CLIENT_SECRET", "test-secret")
+        os.environ.setdefault("DATABASE_URL", "postgresql://test")
+        os.environ.setdefault("TOKEN_ENCRYPTION_KEY", "x" * 44)
+
+        from config import Settings  # type: ignore[import-not-found]
+
+        scopes = set(Settings().google_scopes.split())
+        missing = REQUIRED_SCOPES - scopes
+        self.assertEqual(
+            missing,
+            set(),
+            "Settings.google_scopes is missing scopes required by deployed "
+            f"publishers (would re-introduce ACCESS_TOKEN_SCOPE_INSUFFICIENT): {sorted(missing)}",
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- Adds `drive.metadata.readonly`, `drive.readonly`, and `documents.readonly` to `Settings.google_scopes` so newly minted access tokens authorize `DriveFiles.List`, `files.export`, and Docs read-by-ID — fixing the `ACCESS_TOKEN_SCOPE_INSUFFICIENT` 403 hit by the `google-drive` publisher.
- Documents the new scopes in `README.md` (with a re-consent note for existing refresh tokens).
- Adds `tests/test_google_scopes.py`: one regression test that pins every scope a deployed publisher in this repo requires, so a future removal trips CI instead of production.

Closes #18.

## Test plan
- [x] `python -m unittest tests.test_google_scopes` — passes locally.
- [ ] After merge + redeploy of `seren-auth`, force a fresh OAuth flow and confirm `oauth2.googleapis.com/tokeninfo` returns the three new scopes.
- [ ] Verify `GET /files?pageSize=10&q=mimeType%3D%27application%2Fvnd.google-apps.document%27%20and%20fullText%20contains%20%27PeggyJV%27` returns `200 OK` instead of 403.
- [ ] Verify `GET /files/{fileId}/export` succeeds for a Google Doc.

## Notes
- Existing refresh tokens do **not** automatically gain new scopes — affected users must re-run the OAuth flow after redeploy. Consider purging stale refresh-token rows if needed.
- Google Cloud OAuth consent screen must list the three new scopes; verification may be required if any are flagged sensitive/restricted.
- Pre-existing `cloudbuild-nano-banana.yaml` (untracked) is unrelated to this PR.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
