### PR TITLE
fix(gmail): accept JSON body on modify/labels + add batchModify (#20)

### DIFF
--- a/gmail/client.py
+++ b/gmail/client.py
@@ -252,6 +252,34 @@ class GmailClient:
             body["removeLabelIds"] = remove_label_ids
         return await self._request("POST", f"/users/{user_id}/messages/{message_id}/modify", json=body)
 
+    async def batch_modify_messages(
+        self,
+        ids: List[str],
+        add_label_ids: Optional[List[str]] = None,
+        remove_label_ids: Optional[List[str]] = None,
+        user_id: str = "me",
+    ) -> None:
+        """Apply label changes to up to 1000 messages in one Gmail call.
+
+        Wraps Gmail's ``users.messages.batchModify`` endpoint, which returns
+        204 No Content on success.
+        """
+        body: Dict[str, Any] = {"ids": ids}
+        if add_label_ids:
+            body["addLabelIds"] = add_label_ids
+        if remove_label_ids:
+            body["removeLabelIds"] = remove_label_ids
+
+        url = f"{self.base_url}/users/{user_id}/messages/batchModify"
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                url,
+                headers=self._headers(),
+                json=body,
+                timeout=self.timeout,
+            )
+            response.raise_for_status()
+
     # Labels
 
     async def list_labels(self, user_id: str = "me") -> Dict[str, Any]:

--- a/gmail/main.py
+++ b/gmail/main.py
@@ -89,6 +89,40 @@ def _query_bool(request: Request, default: bool, *names: str) -> bool:
     return value.lower() in {"1", "true", "yes", "on"}
 
 
+async def _json_body(request: Request) -> dict:
+    """Best-effort parse of a JSON request body.
+
+    Gmail's canonical API shape sends modify/label parameters in the JSON
+    body. Earlier versions of these routes only read query params, which
+    silently dropped body fields. We now accept either: body wins when
+    both are present, query params remain a working fallback.
+    """
+    if not request.headers.get("content-type", "").lower().startswith("application/json"):
+        return {}
+    try:
+        data = await request.json()
+    except Exception:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _coerce_str_list(value) -> Optional[List[str]]:
+    """Coerce a JSON body value into a list[str], or None if unusable.
+
+    Accepts a list of strings or a single string. Returns None for missing,
+    empty, or non-string entries so callers can chain ``or`` against query
+    params without false positives.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return [value] if value else None
+    if isinstance(value, list):
+        coerced = [v for v in value if isinstance(v, str)]
+        return coerced or None
+    return None
+
+
 @app.get("/health")
 async def health_check():
     """Health check endpoint."""
@@ -249,16 +283,73 @@ async def modify_message(
     remove_label_ids: Optional[List[str]] = Query(None, alias="removeLabelIds"),
     client: GmailClient = Depends(get_gmail_client),
 ):
-    """Modify message labels."""
+    """Modify message labels.
+
+    Accepts ``addLabelIds`` / ``removeLabelIds`` from the JSON body
+    (canonical Gmail API shape) or from repeated query params. Body wins
+    when both are present.
+    """
     try:
-        add_label_ids = _query_values(request, "addLabelIds", "add_label_ids") or add_label_ids
-        remove_label_ids = _query_values(request, "removeLabelIds", "remove_label_ids") or remove_label_ids
+        body = await _json_body(request)
+
+        add_label_ids = (
+            _coerce_str_list(body.get("addLabelIds"))
+            or _coerce_str_list(body.get("add_label_ids"))
+            or _query_values(request, "addLabelIds", "add_label_ids")
+            or add_label_ids
+        )
+        remove_label_ids = (
+            _coerce_str_list(body.get("removeLabelIds"))
+            or _coerce_str_list(body.get("remove_label_ids"))
+            or _query_values(request, "removeLabelIds", "remove_label_ids")
+            or remove_label_ids
+        )
 
         return await client.modify_message(
             message_id=message_id,
             add_label_ids=add_label_ids,
             remove_label_ids=remove_label_ids,
         )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
+
+@app.post("/messages/batchModify")
+async def batch_modify_messages(
+    request: Request,
+    client: GmailClient = Depends(get_gmail_client),
+):
+    """Batch-modify labels on up to 1000 messages in a single Gmail call.
+
+    Body shape matches Gmail's ``users.messages.batchModify``:
+    ``{"ids": [...], "addLabelIds": [...], "removeLabelIds": [...]}``.
+    Reduces gateway load for sweeps that would otherwise issue N
+    individual ``/messages/{id}/modify`` calls.
+    """
+    body = await _json_body(request)
+
+    ids = _coerce_str_list(body.get("ids"))
+    if not ids:
+        raise HTTPException(status_code=422, detail="ids must be a non-empty list of message IDs")
+    if len(ids) > 1000:
+        raise HTTPException(status_code=422, detail="ids may contain at most 1000 entries")
+
+    add_label_ids = _coerce_str_list(body.get("addLabelIds")) or _coerce_str_list(body.get("add_label_ids"))
+    remove_label_ids = _coerce_str_list(body.get("removeLabelIds")) or _coerce_str_list(body.get("remove_label_ids"))
+
+    if not add_label_ids and not remove_label_ids:
+        raise HTTPException(
+            status_code=422,
+            detail="At least one of addLabelIds or removeLabelIds must be provided",
+        )
+
+    try:
+        await client.batch_modify_messages(
+            ids=ids,
+            add_label_ids=add_label_ids,
+            remove_label_ids=remove_label_ids,
+        )
+        return {"status": "ok", "count": len(ids)}
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
 
@@ -288,12 +379,43 @@ async def get_label(
 
 @app.post("/labels")
 async def create_label(
-    name: str,
-    message_list_visibility: str = "show",
-    label_list_visibility: str = "labelShow",
+    request: Request,
+    name: Optional[str] = Query(None),
+    message_list_visibility: Optional[str] = Query(None, alias="messageListVisibility"),
+    label_list_visibility: Optional[str] = Query(None, alias="labelListVisibility"),
     client: GmailClient = Depends(get_gmail_client),
 ):
-    """Create a new label."""
+    """Create a new label.
+
+    Accepts ``name`` / ``messageListVisibility`` / ``labelListVisibility``
+    in the JSON body (canonical Gmail API shape) or as query params. Body
+    wins when both are present.
+    """
+    body = await _json_body(request)
+
+    name = (
+        body.get("name")
+        or _query_value(request, "name")
+        or name
+    )
+    if not isinstance(name, str) or not name:
+        raise HTTPException(status_code=422, detail="name is required")
+
+    message_list_visibility = (
+        body.get("messageListVisibility")
+        or body.get("message_list_visibility")
+        or _query_value(request, "messageListVisibility", "message_list_visibility")
+        or message_list_visibility
+        or "show"
+    )
+    label_list_visibility = (
+        body.get("labelListVisibility")
+        or body.get("label_list_visibility")
+        or _query_value(request, "labelListVisibility", "label_list_visibility")
+        or label_list_visibility
+        or "labelShow"
+    )
+
     try:
         return await client.create_label(
             name=name,

--- a/gmail/tests/test_modify_message_body.py
+++ b/gmail/tests/test_modify_message_body.py
@@ -1,0 +1,159 @@
+import unittest
+
+from fastapi.testclient import TestClient
+
+import main as gmail_main
+
+
+class FakeGmailClient:
+    def __init__(self):
+        self.modify_calls = []
+        self.batch_modify_calls = []
+        self.create_label_calls = []
+
+    async def modify_message(self, **kwargs):
+        self.modify_calls.append(kwargs)
+        return {"id": kwargs["message_id"], "labelIds": kwargs.get("add_label_ids") or []}
+
+    async def batch_modify_messages(self, **kwargs):
+        self.batch_modify_calls.append(kwargs)
+        return None
+
+    async def create_label(self, **kwargs):
+        self.create_label_calls.append(kwargs)
+        return {"id": "Label_999", **kwargs}
+
+
+class ModifyMessageBodyTests(unittest.TestCase):
+    """Issue #20: POST /messages/{id}/modify must accept addLabelIds /
+    removeLabelIds in the JSON body (the canonical Gmail API shape), not just
+    repeated query params."""
+
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_modify_accepts_label_ids_from_json_body(self):
+        response = self.client.post(
+            "/messages/MSG123/modify",
+            json={"addLabelIds": ["Label_116"], "removeLabelIds": ["INBOX"]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.modify_calls[-1],
+            {
+                "message_id": "MSG123",
+                "add_label_ids": ["Label_116"],
+                "remove_label_ids": ["INBOX"],
+            },
+        )
+
+    def test_modify_still_accepts_repeated_query_params(self):
+        response = self.client.post(
+            "/messages/MSG123/modify?addLabelIds=Label_A&addLabelIds=Label_B&removeLabelIds=INBOX",
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.modify_calls[-1],
+            {
+                "message_id": "MSG123",
+                "add_label_ids": ["Label_A", "Label_B"],
+                "remove_label_ids": ["INBOX"],
+            },
+        )
+
+    def test_modify_body_takes_precedence_over_query_params(self):
+        response = self.client.post(
+            "/messages/MSG123/modify?addLabelIds=QUERY_ONLY",
+            json={"addLabelIds": ["BODY_WINS"]},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.modify_calls[-1]["add_label_ids"],
+            ["BODY_WINS"],
+        )
+
+
+class CreateLabelBodyTests(unittest.TestCase):
+    """Issue #20 follow-up: POST /labels has the same bug — accepts only query
+    params. Must also accept the canonical Gmail API JSON body shape."""
+
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_create_label_accepts_json_body(self):
+        response = self.client.post(
+            "/labels",
+            json={
+                "name": "Newsletters/Inbox",
+                "messageListVisibility": "show",
+                "labelListVisibility": "labelShow",
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.create_label_calls[-1],
+            {
+                "name": "Newsletters/Inbox",
+                "message_list_visibility": "show",
+                "label_list_visibility": "labelShow",
+            },
+        )
+
+
+class BatchModifyMessagesTests(unittest.TestCase):
+    """Issue #20 follow-up: expose POST /messages/batchModify so callers can
+    label up to 1000 IDs in one call instead of N individual POSTs."""
+
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_batch_modify_accepts_ids_and_label_lists_from_body(self):
+        response = self.client.post(
+            "/messages/batchModify",
+            json={
+                "ids": ["MSG1", "MSG2", "MSG3"],
+                "addLabelIds": ["Label_X"],
+                "removeLabelIds": ["INBOX"],
+            },
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"status": "ok", "count": 3})
+        self.assertEqual(
+            self.fake_client.batch_modify_calls[-1],
+            {
+                "ids": ["MSG1", "MSG2", "MSG3"],
+                "add_label_ids": ["Label_X"],
+                "remove_label_ids": ["INBOX"],
+            },
+        )
+
+    def test_batch_modify_rejects_empty_ids(self):
+        response = self.client.post(
+            "/messages/batchModify",
+            json={"ids": [], "addLabelIds": ["Label_X"]},
+        )
+        self.assertEqual(response.status_code, 422)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #20.

- `POST /messages/{id}/modify` now accepts `addLabelIds` / `removeLabelIds` in the **JSON body** (canonical Gmail API shape). Previously these were read only from query params and the body was silently dropped, causing Google to return `400 INVALID_ARGUMENT: No label or Classification Label updates provided`.
- `POST /labels` now accepts `name` / `messageListVisibility` / `labelListVisibility` in the JSON body. Same root cause as the modify route.
- Adds `POST /messages/batchModify` proxying Gmail's native batch endpoint (up to 1000 IDs/call). Reduces gateway load for sweeps like the Newsletter Digest backfill (36 messages -> 1 call instead of 36).

Body wins when both body and query params are present. Query-param callers continue to work - repeated `?addLabelIds=...&addLabelIds=...` still parses as a list.

## Test plan

- [x] New `tests/test_modify_message_body.py` covers:
  - `modify` accepts label IDs from JSON body
  - `modify` still accepts repeated query params (backward compat)
  - body wins over query params when both present
  - `create_label` accepts JSON body
  - `batchModify` accepts ids + label lists from body
  - `batchModify` rejects empty ids with 422
- [x] Full gmail test suite: 12/12 green (6 baseline + 6 new)
- [ ] Functional test post-deploy: `curl -X POST .../messages/<id>/modify -d '{"addLabelIds":["..."]}'` returns 200

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
