### PR TITLE
fix(gmail): add PUT/DELETE on /drafts/{draft_id} (#22)

### DIFF
--- a/gmail/client.py
+++ b/gmail/client.py
@@ -503,3 +503,39 @@ class GmailClient:
         """Send a draft."""
         body = {"id": draft_id}
         return await self._request("POST", f"/users/{user_id}/drafts/send", json=body)
+
+    async def update_draft(
+        self,
+        draft_id: str,
+        raw: str,
+        thread_id: Optional[str] = None,
+        user_id: str = "me",
+    ) -> Dict[str, Any]:
+        """Replace the contents of an existing draft.
+
+        Wraps Gmail's ``users.drafts.update`` (HTTP PUT). The Gmail API does
+        not expose a PATCH for drafts; the entire message body is replaced.
+        """
+        message: Dict[str, Any] = {"raw": raw}
+        if thread_id:
+            message["threadId"] = thread_id
+        body = {"message": message}
+        return await self._request("PUT", f"/users/{user_id}/drafts/{draft_id}", json=body)
+
+    async def delete_draft(
+        self,
+        draft_id: str,
+        user_id: str = "me",
+    ) -> None:
+        """Permanently delete a draft.
+
+        Wraps Gmail's ``users.drafts.delete`` which returns 204 No Content.
+        """
+        url = f"{self.base_url}/users/{user_id}/drafts/{draft_id}"
+        async with httpx.AsyncClient() as client:
+            response = await client.delete(
+                url,
+                headers=self._headers(),
+                timeout=self.timeout,
+            )
+            response.raise_for_status()

--- a/gmail/main.py
+++ b/gmail/main.py
@@ -15,7 +15,7 @@ from shared.auth import get_token_from_header
 from shared.config import get_settings
 
 from client import GmailClient
-from models import SendMessageRequest, FriendlySendRequest
+from models import SendMessageRequest, FriendlySendRequest, UpdateDraftRequest
 
 # Configure logging
 settings = get_settings()
@@ -546,6 +546,41 @@ async def send_draft(
     """Send a draft."""
     try:
         return await client.send_draft(draft_id=draft_id)
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
+
+@app.put("/drafts/{draft_id}")
+async def update_draft(
+    draft_id: str,
+    request: UpdateDraftRequest,
+    client: GmailClient = Depends(get_gmail_client),
+):
+    """Replace the contents of an existing draft.
+
+    Mirrors Gmail's ``users.drafts.update`` (PUT). Body shape is
+    ``{"raw": "<base64url>", "threadId": "<optional>"}``. Returns the
+    updated draft, matching the response shape of ``POST /drafts``.
+    """
+    try:
+        return await client.update_draft(
+            draft_id=draft_id,
+            raw=request.raw,
+            thread_id=request.thread_id,
+        )
+    except httpx.HTTPStatusError as e:
+        raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
+
+
+@app.delete("/drafts/{draft_id}", status_code=204)
+async def delete_draft(
+    draft_id: str,
+    client: GmailClient = Depends(get_gmail_client),
+):
+    """Permanently delete a draft. Returns 204 on success, 404 if missing."""
+    try:
+        await client.delete_draft(draft_id=draft_id)
+        return None
     except httpx.HTTPStatusError as e:
         raise HTTPException(status_code=e.response.status_code, detail=e.response.text)
 

--- a/gmail/models.py
+++ b/gmail/models.py
@@ -104,5 +104,11 @@ class DraftRequest(BaseModel):
     message: SendMessageRequest
 
 
+class UpdateDraftRequest(BaseModel):
+    """Request to replace the contents of an existing draft."""
+    raw: str = Field(..., description="Base64url encoded email message (RFC 2822)")
+    thread_id: Optional[str] = Field(None, alias="threadId", description="Thread ID to keep the draft attached to")
+
+
 # Enable forward references for recursive MessagePart
 MessagePart.model_rebuild()

--- a/gmail/tests/test_drafts_update_delete.py
+++ b/gmail/tests/test_drafts_update_delete.py
@@ -1,0 +1,94 @@
+import unittest
+
+import httpx
+from fastapi.testclient import TestClient
+
+import main as gmail_main
+
+
+class FakeGmailClient:
+    def __init__(self):
+        self.update_calls = []
+        self.delete_calls = []
+        self.next_update_response = {"id": "DRAFT123", "message": {"id": "MSG1"}}
+        self.delete_should_404 = False
+
+    async def update_draft(self, **kwargs):
+        self.update_calls.append(kwargs)
+        return self.next_update_response
+
+    async def delete_draft(self, **kwargs):
+        self.delete_calls.append(kwargs)
+        if self.delete_should_404:
+            request = httpx.Request("DELETE", "https://gmail.googleapis.com/gmail/v1/users/me/drafts/missing")
+            response = httpx.Response(status_code=404, request=request, text='{"error":"not found"}')
+            raise httpx.HTTPStatusError("not found", request=request, response=response)
+        return None
+
+
+class UpdateDraftTests(unittest.TestCase):
+    """Issue #22: PUT /drafts/{draft_id} must accept the canonical Gmail draft
+    update body (raw + optional threadId) and return the updated draft."""
+
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_put_draft_replaces_contents(self):
+        response = self.client.put(
+            "/drafts/DRAFT123",
+            json={"raw": "VGVzdDI=", "threadId": "thread-1"},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.json(), {"id": "DRAFT123", "message": {"id": "MSG1"}})
+        self.assertEqual(
+            self.fake_client.update_calls[-1],
+            {"draft_id": "DRAFT123", "raw": "VGVzdDI=", "thread_id": "thread-1"},
+        )
+
+    def test_put_draft_without_thread_id(self):
+        response = self.client.put(
+            "/drafts/DRAFT123",
+            json={"raw": "VGVzdA=="},
+        )
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(
+            self.fake_client.update_calls[-1],
+            {"draft_id": "DRAFT123", "raw": "VGVzdA==", "thread_id": None},
+        )
+
+
+class DeleteDraftTests(unittest.TestCase):
+    """Issue #22: DELETE /drafts/{draft_id} must return 204 on success and
+    surface upstream 404 when the draft does not exist."""
+
+    def setUp(self):
+        self.fake_client = FakeGmailClient()
+        gmail_main.app.dependency_overrides[gmail_main.get_gmail_client] = lambda: self.fake_client
+        self.client = TestClient(gmail_main.app)
+
+    def tearDown(self):
+        gmail_main.app.dependency_overrides.clear()
+
+    def test_delete_draft_returns_204(self):
+        response = self.client.delete("/drafts/DRAFT123")
+
+        self.assertEqual(response.status_code, 204)
+        self.assertEqual(self.fake_client.delete_calls[-1], {"draft_id": "DRAFT123"})
+
+    def test_delete_missing_draft_returns_404(self):
+        self.fake_client.delete_should_404 = True
+
+        response = self.client.delete("/drafts/missing")
+
+        self.assertEqual(response.status_code, 404)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Closes #22.

- `PUT /drafts/{draft_id}` now updates an existing draft in place (raw + optional threadId), returning the updated draft.
- `DELETE /drafts/{draft_id}` now permanently deletes a draft, returning 204; surfaces upstream 404 when the id does not exist.
- Adds `UpdateDraftRequest` model and the matching `update_draft` / `delete_draft` client wrappers.

The Gmail REST API uses PUT (not PATCH) for `users.drafts.update`. `delete_draft` bypasses the shared `_request` helper because Gmail returns 204 No Content with an empty body, which the helper cannot parse as JSON.

## Test plan

- [x] `python3 -m pytest gmail/tests/ -v` (16/16 pass, including 4 new tests covering PUT with thread_id, PUT without thread_id, DELETE 204, DELETE 404)
- [ ] Post-deploy functional tests against `seren-gmail` Cloud Run service: create → update → delete a draft via the gateway, confirm no 403 once the publisher manifest is updated to allowlist PUT/DELETE on `/drafts/{draft_id}`.

## Out of scope

The gateway publisher manifest still has `undocumented_endpoint_policy: default_deny` and lists only `GET /drafts`, `POST /drafts`, `POST /drafts/{draft_id}/send`. Until the manifest is updated to allowlist the new methods, the gateway will continue to 403 even with this fix deployed. That manifest lives outside this repo.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
