### PR TITLE
fix(auth): request only consent-screen-declared OAuth scopes (#25)

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,11 +151,28 @@ seren mcp call execute_paid_api --publisher gmail --method GET --path /messages
 - `https://www.googleapis.com/auth/calendar`
 - `https://www.googleapis.com/auth/calendar.events`
 
-**Drive / Docs:**
+**Contacts:**
 
-- `https://www.googleapis.com/auth/drive.metadata.readonly` — required for `files.list` discovery/search
-- `https://www.googleapis.com/auth/drive.readonly` — required for `files.export` content download
-- `https://www.googleapis.com/auth/documents.readonly` — required for Docs API read by document ID
+- `https://www.googleapis.com/auth/contacts.readonly`
+
+**Sheets:**
+
+- `https://www.googleapis.com/auth/spreadsheets` — full read/write for the Sheets publisher
+
+**Docs:**
+
+- `https://www.googleapis.com/auth/documents` — full read/write (Docs publisher does `documents.create` + `documents.batchUpdate`)
+
+**Drive:**
+
+- `https://www.googleapis.com/auth/drive.file` — per-file access for files the user explicitly authorizes through the Drive Picker UI (or that the app creates/shares)
+
+> **Consent-screen alignment.** Every scope above is declared on the production
+> OAuth consent screen. Requesting an undeclared scope causes Google to silently
+> substitute a different (declared) scope at consent time — re-introducing
+> issue #25. Broader Drive scopes (`drive.readonly`, `drive.metadata.readonly`)
+> require Google product review and a CASA attestation; that work is tracked
+> separately.
 
 > **Re-consent required after scope changes.** Existing refresh tokens do not
 > automatically gain newly added scopes — affected users must run the OAuth
@@ -163,7 +180,7 @@ seren mcp call execute_paid_api --publisher gmail --method GET --path /messages
 
 ## Related
 
-- Seren Publishers: `gmail`, `google-calendar`
+- Seren Publishers: `gmail`, `google-calendar`, `google-contacts`, `google-sheets`, `google-docs`
 - Backend API: [https://docs.serendb.com](https://docs.serendb.com)
 
 ## License

--- a/auth/config.py
+++ b/auth/config.py
@@ -21,10 +21,12 @@ class Settings(BaseSettings):
     google_token_url: str = "https://oauth2.googleapis.com/token"
     google_userinfo_url: str = "https://www.googleapis.com/oauth2/v2/userinfo"
 
-    # OAuth scopes for Gmail, Calendar, Drive, and Docs.
-    # Drive scopes are required so the Docs/Drive publishers can discover
-    # documents via files.list and export content via files.export
-    # (issue #18 — ACCESS_TOKEN_SCOPE_INSUFFICIENT on DriveFiles.List).
+    # OAuth scopes for Gmail, Calendar, Contacts, Sheets, Docs, and Drive.
+    # Every scope below is declared and approved on the production OAuth
+    # consent screen. Requesting an undeclared scope causes Google to
+    # silently substitute a different (declared) scope at consent time
+    # (issue #25). Drive access is per-file via the Drive Picker UI
+    # (drive.file), which needs no consent-screen declaration.
     google_scopes: str = (
         "openid email profile "
         "https://www.googleapis.com/auth/gmail.readonly "
@@ -32,9 +34,10 @@ class Settings(BaseSettings):
         "https://www.googleapis.com/auth/gmail.modify "
         "https://www.googleapis.com/auth/calendar "
         "https://www.googleapis.com/auth/calendar.events "
-        "https://www.googleapis.com/auth/drive.metadata.readonly "
-        "https://www.googleapis.com/auth/drive.readonly "
-        "https://www.googleapis.com/auth/documents.readonly"
+        "https://www.googleapis.com/auth/contacts.readonly "
+        "https://www.googleapis.com/auth/spreadsheets "
+        "https://www.googleapis.com/auth/documents "
+        "https://www.googleapis.com/auth/drive.file"
     )
 
     # Database for token storage

--- a/tests/test_google_scopes.py
+++ b/tests/test_google_scopes.py
@@ -1,10 +1,19 @@
-# Critical regression test for serenorg/google-api-services#18.
+# Critical regression test for serenorg/google-api-services#25.
 #
-# The OAuth scope list minted by the auth service must include every scope
-# required by a deployed publisher in this repo. Drive/Docs publishers were
-# returning ACCESS_TOKEN_SCOPE_INSUFFICIENT on DriveFiles.List because the
-# auth service was minting Gmail/Calendar-only tokens. This test fails if a
-# future scope removal breaks Drive discovery, Drive export, or Docs reads.
+# The OAuth scope list minted by the auth service must only request scopes
+# that are DECLARED on the Google consent screen for the production OAuth
+# client. Requesting an undeclared scope causes Google to silently
+# substitute a different (declared) scope at consent time — masking the
+# fact that the user never granted what the code asked for.
+#
+# History:
+#   - Issue #18 added drive.readonly + drive.metadata.readonly + documents.readonly
+#     to fix ACCESS_TOKEN_SCOPE_INSUFFICIENT, but those scopes were never declared
+#     on the consent screen, so Google silently downgraded to drive.file + documents.
+#   - Issue #25 reconciles auth/config.py with the consent screen declaration.
+#
+# Future scope additions must EITHER be declared on the consent screen first
+# OR ship as a separate change paired with the GCP declaration.
 
 from __future__ import annotations
 
@@ -21,6 +30,8 @@ if str(AUTH_DIR) not in sys.path:
     sys.path.insert(0, str(AUTH_DIR))
 
 
+# Scopes that MUST be present — declared on the consent screen and used
+# by a deployed publisher in this repo.
 REQUIRED_SCOPES = {
     # Gmail publisher
     "https://www.googleapis.com/auth/gmail.readonly",
@@ -29,17 +40,31 @@ REQUIRED_SCOPES = {
     # Calendar publisher
     "https://www.googleapis.com/auth/calendar",
     "https://www.googleapis.com/auth/calendar.events",
-    # Drive publisher — files.list discovery (issue #18)
-    "https://www.googleapis.com/auth/drive.metadata.readonly",
-    # Drive publisher — files.export content download (issue #18)
+    # Contacts publisher
+    "https://www.googleapis.com/auth/contacts.readonly",
+    # Sheets publisher (full — declared on consent screen)
+    "https://www.googleapis.com/auth/spreadsheets",
+    # Docs publisher (full — declared on consent screen; client.py does
+    # documents.create and documents.batchUpdate, so the readonly variant
+    # would be insufficient).
+    "https://www.googleapis.com/auth/documents",
+    # Drive publisher — per-file access via Drive Picker UI.
+    # drive.file requires no consent-screen declaration.
+    "https://www.googleapis.com/auth/drive.file",
+}
+
+# Scopes that MUST NOT be present — these were requested by a prior
+# revision but are not declared on the consent screen, so Google silently
+# substituted them. Re-introducing them re-introduces the bug.
+FORBIDDEN_SCOPES = {
     "https://www.googleapis.com/auth/drive.readonly",
-    # Docs publisher — documents.get by document ID (issue #18)
+    "https://www.googleapis.com/auth/drive.metadata.readonly",
     "https://www.googleapis.com/auth/documents.readonly",
 }
 
 
-class GoogleScopesCoverageTests(unittest.TestCase):
-    def test_settings_google_scopes_covers_all_deployed_publishers(self):
+class GoogleScopesConsentScreenAlignmentTests(unittest.TestCase):
+    def setUp(self):
         # Provide the env vars Settings() requires so import succeeds.
         import os
 
@@ -50,13 +75,27 @@ class GoogleScopesCoverageTests(unittest.TestCase):
 
         from config import Settings  # type: ignore[import-not-found]
 
-        scopes = set(Settings().google_scopes.split())
-        missing = REQUIRED_SCOPES - scopes
+        self.scopes = set(Settings().google_scopes.split())
+
+    def test_required_scopes_present(self):
+        missing = REQUIRED_SCOPES - self.scopes
         self.assertEqual(
             missing,
             set(),
             "Settings.google_scopes is missing scopes required by deployed "
-            f"publishers (would re-introduce ACCESS_TOKEN_SCOPE_INSUFFICIENT): {sorted(missing)}",
+            f"publishers: {sorted(missing)}",
+        )
+
+    def test_undeclared_scopes_absent(self):
+        # Re-requesting any of these without a consent-screen declaration
+        # re-introduces issue #25 (silent scope downgrade).
+        present_forbidden = FORBIDDEN_SCOPES & self.scopes
+        self.assertEqual(
+            present_forbidden,
+            set(),
+            "Settings.google_scopes requests scopes not declared on the "
+            "Google consent screen — Google will silently downgrade these "
+            f"and the granted token will not match: {sorted(present_forbidden)}",
         )
 
 


### PR DESCRIPTION
## Summary

- Aligns `auth/config.py:google_scopes` with what the production OAuth consent screen actually declares: drops `drive.readonly`, `drive.metadata.readonly`, and `documents.readonly` (all silently substituted by Google) and replaces them with `drive.file` + the broader `documents` scope.
- Adds the previously missing `contacts.readonly` and `spreadsheets` scopes (closes the issue #14 divergence between `auth/config.py` and the gateway OAuth provider record).
- Updates the regression test to assert both required-present and forbidden-absent invariants so a future scope re-addition without a consent-screen declaration fails CI.
- Updates README OAuth Scopes section to match the new set with an explicit note about consent-screen alignment.

## Test plan

- [x] `pytest tests/test_google_scopes.py` passes (failed without the config fix, confirming TDD red→green)
- [x] Full `pytest tests/` passes (5/5, including cloudbuild config tests)
- [x] Audited `auth/oauth.py:25` — `settings.google_scopes` flows verbatim into the OAuth authorize URL's `scope=` parameter
- [ ] Post-deploy: re-consent against a fresh account (row deleted from `google_tokens`) and verify granted scopes via `oauth2.googleapis.com/tokeninfo?access_token=...` include `drive.file`, `documents`, `spreadsheets`, `contacts.readonly`
- [ ] Post-deploy: `curl -i https://google-auth.serendb.com/auth/google?seren_token=test` and decode the `scope=` query param of the redirect Location

Closes #25.

Taariq Lewis, SerenAI, Paloma, and Volume at https://serendb.com
Email: hello@serendb.com
